### PR TITLE
Added ts-avatar to k8s-with-istio yml

### DIFF
--- a/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
+++ b/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
@@ -1440,6 +1440,42 @@ spec:
           timeoutSeconds: 5 
 ---
 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-avatar-service
+spec:
+  selector:
+    matchLabels:
+      app: ts-avatar-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ts-avatar-service
+    spec:
+      containers:
+      - name: ts-avatar-service
+        image: codewisdom/ts-avatar-service:0.1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 17001
+        resources:
+          requests:
+            cpu: 50m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        readinessProbe:
+          tcpSocket:
+            port: 17001
+          initialDelaySeconds: 160
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -1960,3 +1996,16 @@ spec:
       port: 16101
   selector:
    app: ts-voucher-service
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-avatar-service
+spec:
+  ports:
+    - name: http
+      port: 17001
+  selector:
+   app: ts-avatar-service


### PR DESCRIPTION
I was trying to get train ticket working on Google Cloud with Istio, and I noticed the same problem as in issue #155  - the avatar service is not deployed because it is not a part of the YAML files.  I added it, and now I no longer have the issue mentioned there.