### PR TITLE
feat: 拆分ts-food-map-service为ts-trainfood-service

### DIFF
--- a/deployment/kubernetes-manifests/quickstart-k8s/quickstart-ts-deployment-part1.yml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/quickstart-ts-deployment-part1.yml
@@ -514,6 +514,35 @@ spec:
 
 ---
 
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-trainfood-mongo
+spec:
+  selector:
+    matchLabels:
+      app: ts-trainfood-mongo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ts-trainfood-mongo
+    spec:
+      containers:
+        - name: ts-trainfood-mongo
+          image: mongo
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+
+---
+
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -929,6 +958,19 @@ spec:
     app: ts-food-map-mongo
 
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-trainfood-mongo
+spec:
+  ports:
+    - port: 27017
+  selector:
+    app: ts-trainfood-mongo
+
+---
+
 
 apiVersion: v1
 kind: Service

--- a/deployment/kubernetes-manifests/quickstart-k8s/quickstart-ts-deployment-part2.yml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/quickstart-ts-deployment-part2.yml
@@ -559,6 +559,48 @@ spec:
             timeoutSeconds: 5
 ---
 
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-trainfood-service
+spec:
+  selector:
+    matchLabels:
+      app: ts-trainfood-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ts-trainfood-service
+    spec:
+      containers:
+        - name: ts-trainfood-service
+          image: codewisdom/ts-trainfood-service:0.2.0
+          imagePullPolicy: Always
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          ports:
+            - containerPort: 19999
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
+          readinessProbe:
+            tcpSocket:
+              port: 18855
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+---
+
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1856,6 +1898,20 @@ spec:
     app: ts-food-map-service
 
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ts-trainfood-service
+spec:
+  ports:
+    - name: http
+      port: 19999
+  selector:
+    app: ts-trainfood-service
+
+---
+
 
 apiVersion: v1
 kind: Service

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
         <module>ts-auth-service</module>
         <module>ts-user-service</module>
         <module>ts-delivery-service</module>
+
+        <module>ts-trainfood-service</module>
         <!--<module>ts-ticket-advance-service</module>-->
         <!--<module>1_services_analysis_mvn</module>-->
     </modules>

--- a/ts-food-service/src/main/java/foodsearch/service/FoodServiceImpl.java
+++ b/ts-food-service/src/main/java/foodsearch/service/FoodServiceImpl.java
@@ -210,7 +210,7 @@ public class FoodServiceImpl implements FoodService {
         /**--------------------------------------------------------------------------------------*/
         HttpEntity requestEntityGetTrainFoodListResult = new HttpEntity(null);
         ResponseEntity<Response<List<TrainFood>>> reGetTrainFoodListResult = restTemplate.exchange(
-                "http://ts-food-map-service:18855/api/v1/foodmapservice/trainfoods/" + tripId,
+                "http://ts-trainfood-service:19999/api/v1/trainfoodservice/trainfoods/" + tripId,
                 HttpMethod.GET,
                 requestEntityGetTrainFoodListResult,
                 new ParameterizedTypeReference<Response<List<TrainFood>>>() {

--- a/ts-trainfood-service/Dockerfile
+++ b/ts-trainfood-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-jre
+
+RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
+
+ADD ./target/ts-trainfood-service-1.0.jar /app/
+CMD ["java", "-Xmx200m",  "-jar", "/app/ts-trainfood-service-1.0.jar"]
+
+EXPOSE 19999

--- a/ts-trainfood-service/pom.xml
+++ b/ts-trainfood-service/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fdse.microservice</groupId>
+    <artifactId>ts-trainfood-service</artifactId>
+    <version>1.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.services</groupId>
+            <artifactId>ts-common</artifactId>
+            <version>0.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <packaging>jar</packaging>
+
+    <name>ts-trainfood-service</name>
+
+    <parent>
+        <groupId>org.services</groupId>
+        <artifactId>ts-service</artifactId>
+        <version>0.1.0</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+    </properties>
+
+</project>

--- a/ts-trainfood-service/src/main/java/trainfood/TrainFoodApplication.java
+++ b/ts-trainfood-service/src/main/java/trainfood/TrainFoodApplication.java
@@ -1,0 +1,20 @@
+package trainfood;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.integration.annotation.IntegrationComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@SpringBootApplication
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@EnableAsync
+@IntegrationComponentScan
+@EnableSwagger2
+public class TrainFoodApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TrainFoodApplication.class, args);
+    }
+}

--- a/ts-trainfood-service/src/main/java/trainfood/config/SecurityConfig.java
+++ b/ts-trainfood-service/src/main/java/trainfood/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package trainfood.config;
+
+import edu.fudan.common.security.jwt.JWTFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import static org.springframework.web.cors.CorsConfiguration.ALL;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    // load password encoder
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     *  allow cors domain
+     * header 在默认的情况下只能从头部取出6个字段，想要其他字段只能自己在头里指定
+     * credentials 默认不发送Cookie, 如果需要Cookie,这个值只能为true
+     * 本次请求检查的有效期
+     *
+     * @return
+     */
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurerAdapter() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(ALL)
+                        .allowedMethods(ALL)
+                        .allowedHeaders(ALL)
+                        .allowCredentials(false)
+                        .maxAge(3600);
+            }
+        };
+    }
+
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.httpBasic().disable()
+                // close default csrf
+                .csrf().disable()
+                // close session
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/v1/trainfoodservice/**").permitAll()
+                .antMatchers("/swagger-ui.html", "/webjars/**", "/images/**",
+                        "/configuration/**", "/swagger-resources/**", "/v2/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JWTFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        // close cache
+        httpSecurity.headers().cacheControl();
+    }
+}

--- a/ts-trainfood-service/src/main/java/trainfood/controller/TrainFoodController.java
+++ b/ts-trainfood-service/src/main/java/trainfood/controller/TrainFoodController.java
@@ -1,0 +1,40 @@
+package trainfood.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+import trainfood.service.TrainFoodService;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequestMapping("/api/v1/trainfoodservice")
+public class TrainFoodController {
+
+    @Autowired
+    TrainFoodService trainFoodService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TrainFoodController.class);
+
+    @GetMapping(path = "/trainfoods/welcome")
+    public String home() {
+        return "Welcome to [ Train Food Service ] !";
+    }
+
+    @CrossOrigin(origins = "*")
+    @GetMapping("/trainfoods")
+    public HttpEntity getAllTrainFood(@RequestHeader HttpHeaders headers) {
+        TrainFoodController.LOGGER.info("[Food Map Service][Get All TrainFoods]");
+        return ok(trainFoodService.listTrainFood(headers));
+    }
+
+    @CrossOrigin(origins = "*")
+    @GetMapping("/trainfoods/{tripId}")
+    public HttpEntity getTrainFoodOfTrip(@PathVariable String tripId, @RequestHeader HttpHeaders headers) {
+        TrainFoodController.LOGGER.info("[Food Map Service][Get TrainFoods By TripId]");
+        return ok(trainFoodService.listTrainFoodByTripId(tripId, headers));
+    }
+}

--- a/ts-trainfood-service/src/main/java/trainfood/entity/Food.java
+++ b/ts-trainfood-service/src/main/java/trainfood/entity/Food.java
@@ -1,0 +1,17 @@
+package trainfood.entity;
+
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class Food implements Serializable{
+
+    private String foodName;
+    private double price;
+    public Food(){
+        //Default Constructor
+    }
+
+}

--- a/ts-trainfood-service/src/main/java/trainfood/entity/TrainFood.java
+++ b/ts-trainfood-service/src/main/java/trainfood/entity/TrainFood.java
@@ -1,0 +1,30 @@
+package trainfood.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Document(collection = "trainfoods")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TrainFood {
+
+    @Id
+    private UUID id;
+
+    @NotNull
+    private String tripId;
+
+    private List<Food> foodList;
+
+    public TrainFood(){
+        //Default Constructor
+        this.tripId = "";
+    }
+
+}

--- a/ts-trainfood-service/src/main/java/trainfood/init/InitData.java
+++ b/ts-trainfood-service/src/main/java/trainfood/init/InitData.java
@@ -1,0 +1,68 @@
+package trainfood.init;
+
+import trainfood.entity.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import trainfood.entity.Food;
+import trainfood.entity.TrainFood;
+import trainfood.service.TrainFoodService;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class InitData implements CommandLineRunner{
+
+    @Autowired
+    TrainFoodService trainFoodService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InitData.class);
+
+
+    @Override
+    public void run(String... args) throws Exception {
+        BufferedReader br2 = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream("/trainfood.txt")));
+        try{
+            String line2 = br2.readLine();
+            while( line2 != null ){
+                if( !line2.trim().equals("") ){
+                    TrainFood tf = new TrainFood();
+                    tf.setId(UUID.randomUUID());
+                    String[] lineTemp = line2.trim().split("=");
+                    tf.setTripId(lineTemp[1]);
+                    lineTemp = br2.readLine().trim().split("=");
+                    tf.setFoodList(toFoodList(lineTemp[1]));
+                    trainFoodService.createTrainFood(tf,null);
+                }
+                line2 = br2.readLine();
+            }
+
+        } catch(Exception e){
+            InitData.LOGGER.info("the trainfood.txt has format error!");
+            InitData.LOGGER.error(e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private List<Food> toFoodList(String s){
+        InitData.LOGGER.info("s= {}", s);
+        String[] foodstring = s.split("_");
+        List<Food> foodList = new ArrayList<>();
+        for(int i = 0; i< foodstring.length; i++){
+            String[] foodTemp = foodstring[i].split(",");
+            Food food = new Food();
+            food.setFoodName(foodTemp[0]);
+
+            food.setPrice(Double.parseDouble(foodTemp[1]));
+
+            foodList.add(food);
+        }
+        return foodList;
+    }
+}

--- a/ts-trainfood-service/src/main/java/trainfood/repository/TrainFoodRepository.java
+++ b/ts-trainfood-service/src/main/java/trainfood/repository/TrainFoodRepository.java
@@ -1,0 +1,25 @@
+package trainfood.repository;
+
+
+import food.entity.*;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+import trainfood.entity.TrainFood;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface TrainFoodRepository extends MongoRepository<TrainFood, String> {
+
+    TrainFood findById(UUID id);
+
+    @Override
+    List<TrainFood> findAll();
+
+    @Query("{ 'tripId' : ?0 }")
+    List<TrainFood> findByTripId(String tripId);
+
+    void deleteById(UUID id);
+}

--- a/ts-trainfood-service/src/main/java/trainfood/service/TrainFoodService.java
+++ b/ts-trainfood-service/src/main/java/trainfood/service/TrainFoodService.java
@@ -1,0 +1,13 @@
+package trainfood.service;
+
+import edu.fudan.common.util.Response;
+import org.springframework.http.HttpHeaders;
+import trainfood.entity.*;
+
+public interface TrainFoodService {
+    TrainFood createTrainFood(TrainFood tf, HttpHeaders headers);
+
+    Response listTrainFood(HttpHeaders headers);
+
+    Response listTrainFoodByTripId(String tripId, HttpHeaders headers);
+}

--- a/ts-trainfood-service/src/main/java/trainfood/service/TrainFoodServiceImpl.java
+++ b/ts-trainfood-service/src/main/java/trainfood/service/TrainFoodServiceImpl.java
@@ -1,0 +1,51 @@
+package trainfood.service;
+
+import edu.fudan.common.util.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import trainfood.entity.*;
+import trainfood.repository.TrainFoodRepository;
+
+import java.util.List;
+
+@Service
+public class TrainFoodServiceImpl implements TrainFoodService{
+
+    @Autowired
+    TrainFoodRepository trainFoodRepository;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TrainFoodServiceImpl.class);
+
+    String success = "Success";
+    String noContent = "No content";
+
+    @Override
+    public TrainFood createTrainFood(TrainFood tf, HttpHeaders headers) {
+        TrainFood tfTemp = trainFoodRepository.findById(tf.getId());
+        if (tfTemp != null) {
+            TrainFoodServiceImpl.LOGGER.error("[Init TrainFood] Already Exists Id: {}", tf.getId());
+        } else {
+            trainFoodRepository.save(tf);
+        }
+        return tf;
+    }
+
+    @Override
+    public Response listTrainFood(HttpHeaders headers) {
+        List<TrainFood> trainFoodList = trainFoodRepository.findAll();
+        if (trainFoodList != null && !trainFoodList.isEmpty()) {
+            return new Response<>(1, success, trainFoodList);
+        } else {
+            TrainFoodServiceImpl.LOGGER.error("List train food error: {}", noContent);
+            return new Response<>(0, noContent, null);
+        }
+    }
+
+    @Override
+    public Response listTrainFoodByTripId(String tripId, HttpHeaders headers) {
+        return null;
+    }
+}

--- a/ts-trainfood-service/src/main/resources/application.yml
+++ b/ts-trainfood-service/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 19999
+
+spring:
+  application:
+    name: ts-trainfood-service
+  data:
+    mongodb:
+      host: ts-trainfood-mongo
+#      username: user
+#      password: ${MONGODB_PASSWORD}
+      database: ts
+      port: 27017
+
+swagger:
+  controllerPackage: trainfood.controller

--- a/ts-trainfood-service/src/main/resources/trainfood.txt
+++ b/ts-trainfood-service/src/main/resources/trainfood.txt
@@ -1,0 +1,14 @@
+tripId=G1234
+foodList=Pork Chop with rice,9.5_Egg Soup,3.2
+
+tripId=G1235
+foodList=Beef with rice,9.5_Soup,3.7_Pork pickled mustard green noodles,10
+
+tripId=G1236
+foodList=Seafood noodles,9.5_Glutinous rice,0.9_Dumplings,5.5
+
+tripId=G1237
+foodList=Spring rolls,1.5_Vegetable soup,0.8_Rice and vegetable roll,1
+
+tripId=D1345
+foodList=Spicy hot noodles,5_Soup,3.7_Oily bean curd,2


### PR DESCRIPTION
拆分ts-food-map-service为ts-trainfood-service，修改点：

- 创建服务：ts-trainfood-service，服务端口号暂时设为19999，服务逻辑与原来一样
- 修改k8s部署文件1和2，将原来food-map服务的deployment、service替换为trainfood服务
- 父pom增加module：ts-trainfood-service
- ts-food-service中getAllFood方法对原来food-map的调用修改为对trainfood服务的调用