### PR TITLE
Move down more general rule

### DIFF
--- a/deployment/kubernetes-manifests/k8s-with-istio/trainticket-gateway.yaml
+++ b/deployment/kubernetes-manifests/k8s-with-istio/trainticket-gateway.yaml
@@ -369,17 +369,17 @@ spec:
           number: 16114
   - match:
     - uri:
-        prefix: /
-    route:
-    - destination:
-        host: kafka
-        port:
-          number: 16116
-  - match:
-    - uri:
         prefix: /api/v1/adminuserservice/users
     route:
     - destination:
         host: ts-admin-user-service
         port:
           number: 16115
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: kafka
+        port:
+          number: 16116


### PR DESCRIPTION
Hello,  I tried to deploy train-ticket using Istio-deplyoment, so I prepared the ansible cookbook:

```
- name: Clone train-ticket repo
   ansible.builtin.git:
     repo: 'https://github.com/FudanSELab/train-ticket.git'
     dest: train-ticket
     depth: 1

 - name: Deploy databases
   command: kubectl create -f train-ticket/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part1.yml

 - name: Deploy services
   command: kubectl create -f train-ticket/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml

 - name: Deploy UI
   command: kubectl create -f train-ticket/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part3.yml

 - name: Install Istio
   command: istioctl install --skip-confirmation --set profile=demo

 - name: Create Istio gateway
   command: kubectl apply -f train-ticket/deployment/kubernetes-manifests/k8s-with-istio/trainticket-gateway.yaml 
```

It almost worked, but when I opened the admin panel and then changed the tab to the admin user panel, and in the browser I saw the following error:

<img width="824" alt="Screenshot 2022-07-13 at 19 36 13" src="https://user-images.githubusercontent.com/46607934/178961745-42a8721f-6972-4fc6-81f0-544bb8c9472d.png">

and in `istio-ingressgateway` container printed the following error logs:

```
[2022-07-13T19:29:34.762Z] "GET /api/v1/adminuserservice/users HTTP/1.1" 503 NC cluster_not_found - "-" 0 0 0 - "172.31.27.25" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36" "33713451-40a2-9566-b05e-341bd3352f07" "a7fd3a1ba915d490ba940626b00fc5c8-747781355.us-east-1.elb.amazonaws.com" "-" - - 172.31.19.161:8080 172.31.27.25:49655 - -
```

So I invested it and found the cause of the problem. I think there is a problem with the order of defined rules in `trainticket-gateway.yaml`.

The most general rule `prefix: /` is matched to request  `/api/v1/adminuserservice/users` and istio redirect request to `16116` instead of `16115`.

After reordering the rules, the problem no longer occurs and I can add a user in admin panel.
