### PR TITLE
fix the platform condition cmp

### DIFF
--- a/hack/deploy/gen-mysql-secret.sh
+++ b/hack/deploy/gen-mysql-secret.sh
@@ -68,7 +68,7 @@ function update_tt_dp_cm {
 
   cp $dp_sample_yaml $dp_yaml
 
-  if [ "$(uname)"="Darwin" ]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
     sed -i "" "s/nacos/${nacosCM}/g" $dp_yaml
     sed -i "" "s/rabbitmq/${rabbitmqCM}/g" $dp_yaml
   else
@@ -82,7 +82,7 @@ function update_tt_sw_dp_cm {
   rabbitmqCM="$2"
 
   cp $sw_dp_sample_yaml $sw_dp_yaml
-  if [ "$(uname)"="Darwin" ]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
     sed -i "" "s/nacos/${nacosCM}/g" $sw_dp_yaml
     sed -i "" "s/rabbitmq/${rabbitmqCM}/g" $sw_dp_yaml
   else


### PR DESCRIPTION
When running on my Ubuntu, the `update_tt_dp_cm` and `update_tt_sw_dp_cm` will always go to the true branch ("Darwin" branch for MacOS) since there are missing spaces for besides the equal sign, so errors will pop up:
```
Start deployment Step <3/3>: train-ticket services--------------------------------------------
Start to deploy secret of train-ticket services.
Deploying service configurations...
Deploying train-ticket deployments...
sed: can't read s/nacos/nacos/g: No such file or directory
sed: can't read s/rabbitmq/rabbitmq/g: No such file or directory
```
The sed will regard the expression as a file path.

It will be safer to write in my way. 